### PR TITLE
use env variable POSTGRES_USER as replication user in start.sh

### DIFF
--- a/scripts/primary/start.sh
+++ b/scripts/primary/start.sh
@@ -35,7 +35,7 @@ initdb $POSTGRES_INITDB_ARGS --pgdata="$PGDATA"
 # setup postgresql.conf
 touch /tmp/postgresql.conf
 echo "wal_level = replica" >>/tmp/postgresql.conf
-echo "max_wal_senders = 99" >>/tmp/postgresql.conf
+echo "max_wal_senders = 90" >>/tmp/postgresql.conf # default is 10.  value must be less than max_connections minus superuser_reserved_connections. ref: https://www.postgresql.org/docs/11/runtime-config-replication.html#GUC-MAX-WAL-SENDERS
 echo "wal_keep_segments = 32" >>/tmp/postgresql.conf
 
 cat /scripts/primary/postgresql.conf >>/tmp/postgresql.conf
@@ -48,7 +48,7 @@ mv /tmp/postgresql.conf "$PGDATA/postgresql.conf"
 } >>"$PGDATA/pg_hba.conf"
 { echo 'host  all         all         127.0.0.1/32    trust'; } >>"$PGDATA/pg_hba.conf"
 { echo 'host  all         all         0.0.0.0/0       md5'; } >>"$PGDATA/pg_hba.conf"
-{ echo 'host  replication postgres    0.0.0.0/0       md5'; } >>"$PGDATA/pg_hba.conf"
+{ echo "host  replication ${POSTGRES_USER:-postgres}    0.0.0.0/0       md5"; } >>"$PGDATA/pg_hba.conf"
 
 # start postgres
 pg_ctl -D "$PGDATA" -w start


### PR DESCRIPTION

Issue found in kubedb operator 0.12.0 and postgres 10.2-v4. But looks like it affects all supported postgres version, and it is reported as [#661](https://github.com/kubedb/project/issues/661) 

In kubedb postgres manifest, following the example at https://kubedb.com/docs/0.12.0/guides/postgres/quickstart/quickstart/ and use custom secret for superuser, as detailed in https://kubedb.com/docs/0.12.0/concepts/databases/postgres/#spec-databasesecret

In that secret, we can make the superuser has a custom user name (for demo purpose, let's say it is a user called **kdbadmin**). When DB instances are created, **kdbadmin** is set up as a supseruser account; user postgres is disabled for login, and its password is empty.

Now the slave instances all have env variable POSTGRES_PASSWORD set to kdbadmin's password; as a result, slaves try to connect to master instance as user postgres with kdbadmin's password, as you can see the connection attempts can never succeed.

@the-redback @tamalsaha 

