### PR TITLE
Postgres WAL-G archiving and backup using POSTGRES_USER

### DIFF
--- a/scripts/primary/restore.sh
+++ b/scripts/primary/restore.sh
@@ -111,7 +111,7 @@ if [ "$PITR" = true ]; then
   fi
 fi
 
-echo "restore_command = 'wal-g wal-fetch %f %p'" >>/tmp/recovery.conf
+echo "restore_command = 'PGUSER=${POSTGRES_USER:-postgres} wal-g wal-fetch %f %p'" >>/tmp/recovery.conf
 mv /tmp/recovery.conf "$PGDATA/recovery.conf"
 
 # setup postgresql.conf
@@ -127,7 +127,7 @@ fi
 
 if [ "$ARCHIVE" == "wal-g" ]; then
   # setup postgresql.conf
-  echo "archive_command = 'wal-g wal-push %p'" >>/tmp/postgresql.conf
+  echo "archive_command = '(export PGUSER=${POSTGRES_USER:-postgres}; wal-g wal-push %p)'" >>/tmp/postgresql.conf
   echo "archive_timeout = 60" >>/tmp/postgresql.conf
   echo "archive_mode = always" >>/tmp/postgresql.conf
 fi

--- a/scripts/primary/run.sh
+++ b/scripts/primary/run.sh
@@ -54,7 +54,7 @@ if [ "$ARCHIVE" == "wal-g" ]; then
       export AWS_ENDPOINT=$ARCHIVE_S3_ENDPOINT
       export AWS_S3_FORCE_PATH_STYLE="true"
       export AWS_REGION="us-east-1"
-      [[ -e "$ARCHIVE_S3_REGION" ]] && export AWS_REGION=$ARCHIVE_S3_REGION
+      [[ -e "$CRED_PATH/ARCHIVE_S3_REGION" ]] && export AWS_REGION=$(cat "$CRED_PATH/ARCHIVE_S3_REGION")
     fi
 
   elif [[ ${ARCHIVE_GS_PREFIX} != "" ]]; then
@@ -96,7 +96,7 @@ if [ "$ARCHIVE" == "wal-g" ]; then
   fi
 
   pg_ctl -D "$PGDATA" -w start
-  PGUSER="postgres" wal-g backup-push "$PGDATA"
+  (export PGUSER=${POSTGRES_USER:-postgres}; wal-g backup-push "$PGDATA")
   pg_ctl -D "$PGDATA" -m fast -w stop
 fi
 

--- a/scripts/primary/start.sh
+++ b/scripts/primary/start.sh
@@ -48,7 +48,7 @@ mv /tmp/postgresql.conf "$PGDATA/postgresql.conf"
 } >>"$PGDATA/pg_hba.conf"
 { echo 'host  all         all         127.0.0.1/32    trust'; } >>"$PGDATA/pg_hba.conf"
 { echo 'host  all         all         0.0.0.0/0       md5'; } >>"$PGDATA/pg_hba.conf"
-{ echo 'host  replication postgres    0.0.0.0/0       md5'; } >>"$PGDATA/pg_hba.conf"
+{ echo "host  replication ${POSTGRES_USER:-postgres}    0.0.0.0/0       md5"; } >>"$PGDATA/pg_hba.conf"
 
 # start postgres
 pg_ctl -D "$PGDATA" -w start
@@ -116,7 +116,7 @@ fi
 
 if [ "$ARCHIVE" == "wal-g" ]; then
   # setup postgresql.conf
-  echo "archive_command = 'wal-g wal-push %p'" >>/tmp/postgresql.conf
+  echo "archive_command = '(export PGUSER=${POSTGRES_USER:-postgres}; wal-g wal-push %p)'" >>/tmp/postgresql.conf
   echo "archive_timeout = 60" >>/tmp/postgresql.conf
   echo "archive_mode = always" >>/tmp/postgresql.conf
 fi


### PR DESCRIPTION
I have fixed the issue with archiving and WAL Replication and Backup with the `POSTGRES_USER` environment variable set on the deployment. I have only fixed the 11.2 branch as that is the one I am trying to deploy, but it does not look like the changes will break any of the other branches.

In this fix has a patch for the `ARCHIVE_S3_REGION` (it was causing reboots and crashes on the replicas), based on how the environment variable is being used it looks similar to the other cloud storage secrets. You can toss it if you want and I'll make a new pull request with just that.